### PR TITLE
Feat/benchmark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'jacoco'
 	id 'com.diffplug.spotless' version '6.21.0'
+	id "me.champeau.jmh" version "0.7.2"
 }
 
 repositories {
@@ -34,6 +35,8 @@ test {
 
 dependencies {
 	testImplementation("org.junit.jupiter:junit-jupiter:5.7.2")
+	implementation 'org.openjdk.jmh:jmh-core:1.33'
+	implementation 'org.openjdk.jmh:jmh-generator-annprocess:1.33'
 }
 
 jacocoTestReport {

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -4,9 +4,20 @@ Benchmarks can be ran with `./gradlew jmh`
 
 
 # Result of 07.01.2024 - Using arrays instead of HashSets
+
+## Before 
+```
+PerftBenchmark.position_2kr3r     thrpt    5  10.959 ± 0.117  ops/s
+PerftBenchmark.position_6bR       thrpt    5   5.637 ± 0.151  ops/s
+PerftBenchmark.position_r1b1k1r1  thrpt    5   3.728 ± 0.065  ops/s
+PerftBenchmark.position_r1bQk2r   thrpt    5  69.888 ± 4.363  ops/s
+```
+
+## After
 ```
 Benchmark                          Mode  Cnt   Score   Error  Units
-PerftBenchmark.position_2kr3r     thrpt    5  10.773 ± 0.535  ops/s
-PerftBenchmark.position_r1b1k1r1  thrpt    5   3.971 ± 0.074  ops/s
-PerftBenchmark.position_r1bQk2r   thrpt    5  88.351 ± 2.123  ops/s
+PerftBenchmark.position_2kr3r     thrpt    5  10.853 ± 0.335  ops/s
+PerftBenchmark.position_6bR       thrpt    5   5.647 ± 0.079  ops/s
+PerftBenchmark.position_r1b1k1r1  thrpt    5   3.990 ± 0.067  ops/s
+PerftBenchmark.position_r1bQk2r   thrpt    5  88.009 ± 4.822  ops/s
 ```

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,12 @@
+# Benchmarks
+
+Benchmarks can be ran with `./gradlew jmh`
+
+
+# Result of 07.01.2024 - Using arrays instead of HashSets
+```
+Benchmark                          Mode  Cnt   Score   Error  Units
+PerftBenchmark.position_2kr3r     thrpt    5  10.773 ± 0.535  ops/s
+PerftBenchmark.position_r1b1k1r1  thrpt    5   3.971 ± 0.074  ops/s
+PerftBenchmark.position_r1bQk2r   thrpt    5  88.351 ± 2.123  ops/s
+```

--- a/src/jmh/java/com/github/zerkath/rosemary/PerftBenchmark.java
+++ b/src/jmh/java/com/github/zerkath/rosemary/PerftBenchmark.java
@@ -1,0 +1,47 @@
+package com.github.zerkath.rosemary;
+
+import com.github.zerkath.rosemary.BoardRepresentation.*;
+import com.github.zerkath.rosemary.Main.UCI_Controller;
+import com.github.zerkath.rosemary.MoveGeneration.*;
+import org.openjdk.jmh.annotations.*;
+
+public class PerftBenchmark {
+
+  @Benchmark
+  @Fork(value = 1, warmups = 1)
+  @OutputTimeUnit(java.util.concurrent.TimeUnit.SECONDS)
+  @BenchmarkMode(Mode.Throughput)
+  @Warmup(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  public void position_r1b1k1r1() {
+    UCI_Controller uci = new UCI_Controller();
+    uci.runPerft(
+        4, false, new BoardState("r1b1k1r1/1p3p2/p4b1p/2N5/5q2/8/4PPBP/1RR3K1 b q - 1 27"));
+  }
+
+  @Benchmark
+  @Fork(value = 1, warmups = 1)
+  @OutputTimeUnit(java.util.concurrent.TimeUnit.SECONDS)
+  @BenchmarkMode(Mode.Throughput)
+  @Warmup(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  public void position_r1bQk2r() {
+    UCI_Controller uci = new UCI_Controller();
+    uci.runPerft(
+        4, false, new BoardState("r1bQk2r/ppp2ppp/2p5/2b5/4n3/2N4P/PPP2PP1/R1B1KB1R b KQkq - 0 8"));
+  }
+
+  @Benchmark
+  @Fork(value = 1, warmups = 1)
+  @OutputTimeUnit(java.util.concurrent.TimeUnit.SECONDS)
+  @BenchmarkMode(Mode.Throughput)
+  @Warmup(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  public void position_2kr3r() {
+    UCI_Controller uci = new UCI_Controller();
+    uci.runPerft(
+        4,
+        false,
+        new BoardState("2kr3r/2p4p/2nq1p1n/1N1p2p1/1P1P4/P3PN1P/5PP1/R2Q1RK1 b - - 0 20"));
+  }
+}

--- a/src/jmh/java/com/github/zerkath/rosemary/PerftBenchmark.java
+++ b/src/jmh/java/com/github/zerkath/rosemary/PerftBenchmark.java
@@ -11,8 +11,8 @@ public class PerftBenchmark {
   @Fork(value = 1, warmups = 1)
   @OutputTimeUnit(java.util.concurrent.TimeUnit.SECONDS)
   @BenchmarkMode(Mode.Throughput)
-  @Warmup(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
-  @Measurement(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Warmup(iterations = 5, time = 750, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 750, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void position_r1b1k1r1() {
     UCI_Controller uci = new UCI_Controller();
     uci.runPerft(
@@ -23,8 +23,8 @@ public class PerftBenchmark {
   @Fork(value = 1, warmups = 1)
   @OutputTimeUnit(java.util.concurrent.TimeUnit.SECONDS)
   @BenchmarkMode(Mode.Throughput)
-  @Warmup(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
-  @Measurement(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Warmup(iterations = 5, time = 750, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 750, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void position_r1bQk2r() {
     UCI_Controller uci = new UCI_Controller();
     uci.runPerft(
@@ -35,13 +35,27 @@ public class PerftBenchmark {
   @Fork(value = 1, warmups = 1)
   @OutputTimeUnit(java.util.concurrent.TimeUnit.SECONDS)
   @BenchmarkMode(Mode.Throughput)
-  @Warmup(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
-  @Measurement(iterations = 5, time = 500, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Warmup(iterations = 5, time = 750, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 750, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void position_2kr3r() {
     UCI_Controller uci = new UCI_Controller();
     uci.runPerft(
         4,
         false,
         new BoardState("2kr3r/2p4p/2nq1p1n/1N1p2p1/1P1P4/P3PN1P/5PP1/R2Q1RK1 b - - 0 20"));
+  }
+
+  @Benchmark
+  @Fork(value = 1, warmups = 1)
+  @OutputTimeUnit(java.util.concurrent.TimeUnit.SECONDS)
+  @BenchmarkMode(Mode.Throughput)
+  @Warmup(iterations = 5, time = 750, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 750, timeUnit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  public void position_6bR() {
+    UCI_Controller uci = new UCI_Controller();
+    uci.runPerft(
+        4,
+        false,
+        new BoardState("6bR/1k6/1r6/8/R2q4/KQ2r3/8/5B2 w - - 0 1"));
   }
 }

--- a/src/main/java/com/github/zerkath/rosemary/MoveGeneration/Bishop.java
+++ b/src/main/java/com/github/zerkath/rosemary/MoveGeneration/Bishop.java
@@ -2,7 +2,6 @@ package com.github.zerkath.rosemary.MoveGeneration;
 
 import com.github.zerkath.rosemary.BoardRepresentation.BoardState;
 import com.github.zerkath.rosemary.DataTypes.*;
-import java.util.HashMap;
 
 class BishopMoves {
   Moves downRight = new Moves();
@@ -18,7 +17,7 @@ class BishopMoves {
 public class Bishop extends SlidingPiece {
 
   // Moves should be generated from origin, outwards and be ordered
-  static HashMap<Short, BishopMoves> bishopMoves = new HashMap<>();
+  static BishopMoves[] bishopMoves = new BishopMoves[64];
 
   static {
     for (short origin = 0; origin < 64; origin++) {
@@ -51,7 +50,7 @@ public class Bishop extends SlidingPiece {
           i++) {
         moves.upLeft.add(getMove(-i, -i, origin));
       }
-      bishopMoves.put(origin, moves);
+      bishopMoves[origin] = moves;
     }
   }
 
@@ -61,7 +60,7 @@ public class Bishop extends SlidingPiece {
 
     boolean isWhite = Pieces.isWhite(board.getCoordinate(origin));
 
-    Moves[] allMoves = bishopMoves.get(origin).allMoves;
+    Moves[] allMoves = bishopMoves[origin].allMoves;
 
     for (Moves direction : allMoves) {
       for (short move : direction) {

--- a/src/main/java/com/github/zerkath/rosemary/MoveGeneration/King.java
+++ b/src/main/java/com/github/zerkath/rosemary/MoveGeneration/King.java
@@ -3,11 +3,10 @@ package com.github.zerkath.rosemary.MoveGeneration;
 import com.github.zerkath.rosemary.BoardRepresentation.BoardState;
 import com.github.zerkath.rosemary.DataTypes.*;
 import com.github.zerkath.rosemary.DataTypes.MoveUtil;
-import java.util.HashMap;
 
 public class King {
 
-  static HashMap<Short, Moves> unfilteredMoves = new HashMap<>();
+  static Moves[] unfilteredMoves = new Moves[64];
 
   static {
     for (short origin = 0; origin < 64; origin++) {
@@ -22,7 +21,7 @@ public class King {
           }
         }
       }
-      unfilteredMoves.put(origin, moves);
+      unfilteredMoves[origin] = moves;
     }
   }
 
@@ -38,7 +37,7 @@ public class King {
     int col = MoveUtil.getColumn(origin);
 
     // generating moves around king //todo update
-    for (short move : unfilteredMoves.get(origin)) {
+    for (short move : unfilteredMoves[origin]) {
       if (board.isOpposingColourOrEmpty(MoveUtil.getDestination(move), originalPiece))
         moves.add(move);
     }

--- a/src/main/java/com/github/zerkath/rosemary/MoveGeneration/Knight.java
+++ b/src/main/java/com/github/zerkath/rosemary/MoveGeneration/Knight.java
@@ -2,11 +2,10 @@ package com.github.zerkath.rosemary.MoveGeneration;
 
 import com.github.zerkath.rosemary.BoardRepresentation.BoardState;
 import com.github.zerkath.rosemary.DataTypes.*;
-import java.util.HashMap;
 
 public class Knight {
 
-  static HashMap<Short, Moves> knightMoves = new HashMap<>();
+  static Moves[] knightMoves = new Moves[64];
 
   static {
     for (short origin = 0; origin < 64; origin++) {
@@ -25,14 +24,14 @@ public class Knight {
         Utils.addToCollection(d_row, col + 1, row, col, moves);
         Utils.addToCollection(d_row, col - 1, row, col, moves);
       }
-      knightMoves.put(origin, moves);
+      knightMoves[origin] = moves;
     }
   }
 
   public static void getMoves(short origin, BoardState boardState, Moves moves) {
 
     Board board = boardState.board;
-    Moves n_moves = knightMoves.get(origin);
+    Moves n_moves = knightMoves[origin];
 
     for (short move : n_moves) {
       if (board.isValidMove(move)) moves.add(move);

--- a/src/main/java/com/github/zerkath/rosemary/MoveGeneration/Rook.java
+++ b/src/main/java/com/github/zerkath/rosemary/MoveGeneration/Rook.java
@@ -2,7 +2,6 @@ package com.github.zerkath.rosemary.MoveGeneration;
 
 import com.github.zerkath.rosemary.BoardRepresentation.BoardState;
 import com.github.zerkath.rosemary.DataTypes.*;
-import java.util.HashMap;
 
 class RookMoves {
   Moves up = new Moves();
@@ -18,7 +17,7 @@ class RookMoves {
 public class Rook extends SlidingPiece {
 
   // Moves should be generated from origin, outwards and be ordered
-  static HashMap<Short, RookMoves> rookMoves = new HashMap<>();
+  static RookMoves[] rookMoves = new RookMoves[64];
 
   static {
     for (short origin = 0; origin < 64; origin++) {
@@ -41,7 +40,7 @@ public class Rook extends SlidingPiece {
         moves.down.add(getMove(i, 0, origin));
       }
 
-      rookMoves.put(origin, moves);
+      rookMoves[origin] = moves;
     }
   }
 
@@ -51,7 +50,7 @@ public class Rook extends SlidingPiece {
 
     boolean isWhite = Pieces.isWhite(board.getCoordinate(origin));
 
-    Moves[] allMoves = rookMoves.get(origin).allMoves;
+    Moves[] allMoves = rookMoves[origin].allMoves;
 
     for (Moves direction : allMoves) {
       for (short move : direction) {


### PR DESCRIPTION
- Added JMH for benchmarking
- Changed datastructure for cached moves to arrays instead of HashSets, small improvement in some cases

# Before 
```
PerftBenchmark.position_2kr3r     thrpt    5  10.959 ± 0.117  ops/s
PerftBenchmark.position_6bR       thrpt    5   5.637 ± 0.151  ops/s
PerftBenchmark.position_r1b1k1r1  thrpt    5   3.728 ± 0.065  ops/s
PerftBenchmark.position_r1bQk2r   thrpt    5  69.888 ± 4.363  ops/s
```

# After
```
Benchmark                          Mode  Cnt   Score   Error  Units
PerftBenchmark.position_2kr3r     thrpt    5  10.853 ± 0.335  ops/s
PerftBenchmark.position_6bR       thrpt    5   5.647 ± 0.079  ops/s
PerftBenchmark.position_r1b1k1r1  thrpt    5   3.990 ± 0.067  ops/s
PerftBenchmark.position_r1bQk2r   thrpt    5  88.009 ± 4.822  ops/s
```